### PR TITLE
Add Kodadot NFT Marketplace to ksm.json

### DIFF
--- a/dapps/ksm.json
+++ b/dapps/ksm.json
@@ -1,5 +1,12 @@
 [
   {
+    "title": "Kodadot",
+    "link": "https://kodadot.xyz/",
+    "description": "NFT Explorer running on Kusama and Polkadot",
+    "isFavorites": false,
+    "image": "https://raw.githubusercontent.com/kodadot/kodadot-presskit/main/v3/KDot.svg"
+  },
+  {
     "title": "Singular",
     "link": "https://singular.app/",
     "description": "The Official UI for the first Kusama-native NFTs",


### PR DESCRIPTION
As we've integrated Enkrypt wallet auth in kodadot/nft-gallery#4178, would be cool to add [Kodadot](https://github.com/kodadot) in Kusama "Featured DApps"