### PR TITLE
Fix Changelly CoinGecko Solana token joining

### DIFF
--- a/swap-tokens-generator/src/list-handlers/changelly/index.ts
+++ b/swap-tokens-generator/src/list-handlers/changelly/index.ts
@@ -10,6 +10,9 @@ import {
 
 const CHANGELLY_BASE = `https://partners.mewapi.io/changelly-v2`;
 
+/**
+ * Results from the `CHANGELLY_BASE` URL https://partners.mewapi.io/changelly-v2
+ */
 interface ChangellyCurrency {
   /** @example "EURT" */
   name: string;
@@ -50,33 +53,31 @@ export const formatChangellyCurrencies = (
   /** Changelly Blockchain ID */
   const cPlatform = ChangellyPlatforms[network];
 
+  /** Hardcoded (on this network) token symbol (/ticker) -> lowercase address */
   const contractMap = ChangellyContractMap[network];
 
-  const tokens: Record<string, Token> = {};
+  /** Lowercase (for joining) address -> token */
+  const tokens: Record<Lowercase<string>, Token> = {};
   tokensArr.forEach((t) => {
-    tokens[t.address] = t;
+    tokens[t.address.toLowerCase() as Lowercase<string>] = t;
   });
 
   // Try to find a token for each currency
   currencies.forEach((cur) => {
     // Drop if we don't support swaps on this network
     if (cur.blockchain !== cPlatform) return;
-    if (
-      contractMap &&
-      contractMap[cur.ticker] &&
-      tokens[contractMap[cur.ticker]]
-    ) {
-      // Join the currency's token by ticker symbol
+    if (contractMap?.[cur.ticker] && tokens[contractMap[cur.ticker]]) {
+      // Hard coded known contract, join the currency's token by ticker symbol
       cur.token = tokens[contractMap[cur.ticker]];
     } else if (!cur.contractAddress) {
       // Currency doesn't have an address, it's the native currency of the chain
       cur.token = tokens[NATIVE_ADDRESS];
     } else if (
       cur.contractAddress &&
-      tokens[cur.contractAddress.toLowerCase()]
+      tokens[cur.contractAddress.toLowerCase() as Lowercase<string>]
     ) {
       // Join the currency's token by it's address
-      cur.token = tokens[cur.contractAddress.toLowerCase()];
+      cur.token = tokens[cur.contractAddress.toLowerCase() as Lowercase<string>];
     }
   });
 

--- a/swap-tokens-generator/src/list-handlers/changelly/utils.ts
+++ b/swap-tokens-generator/src/list-handlers/changelly/utils.ts
@@ -11,7 +11,7 @@ import { NetworkName, NetworkType, Token } from "@src/types";
  *
  * ```sh
  * # To get a list of Changely tokens with their blockchain id's
- * curl https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"getCurrenciesFull","params":{}}'
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"getCurrenciesFull","params":{}}'
  * ````
  */
 const ChangellyPlatforms: {
@@ -27,10 +27,11 @@ const ChangellyPlatforms: {
   [NetworkName.Moonbeam]: "glmr",
   [NetworkName.Base]: "BASE",
   [NetworkName.Rootstock]: "rootstock",
+  [NetworkName.Solana]: "solana",
 };
 
 const ChangellyContractMap: {
-  [key in NetworkName]?: Record<string, string>;
+  [key in NetworkName]?: Record<string, Lowercase<string>>;
 } = {
   [NetworkName.Avalanche]: {
     gmx: "0x62edc0692bd897d2295872a9ffcac5425011c661",


### PR DESCRIPTION
Inconsistent casing was causing addresses not to match leading Changelly Solana tokens to be missing CoinGecko info.